### PR TITLE
tabix slicing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,9 @@
         "deque": "cpp",
         "unordered_map": "cpp",
         "vector": "cpp",
-        "system_error": "cpp"
+        "system_error": "cpp",
+        "ostream": "cpp",
+        "stdexcept": "cpp",
+        "cerrno": "cpp"
     }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,11 @@
     "files.associations": {
         "algorithm": "cpp",
         "array": "cpp",
-        "cmath": "cpp"
+        "cmath": "cpp",
+        "*.tcc": "cpp",
+        "deque": "cpp",
+        "unordered_map": "cpp",
+        "vector": "cpp",
+        "system_error": "cpp"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
+include(ExternalProject)
 project(StrawmanSparseVCF LANGUAGES CXX)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -6,16 +7,34 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
 SET(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+ExternalProject_Add(htslib
+    URL https://github.com/samtools/htslib/releases/download/1.8/htslib-1.8.tar.bz2
+    PREFIX ${CMAKE_CURRENT_BINARY_DIR}/external
+    CONFIGURE_COMMAND ""
+    PATCH_COMMAND sed -i "s/^CFLAGS .*$/CFLAGS = -O3 -DNDEBUG -march=ivybridge/" Makefile
+    BUILD_IN_SOURCE 1
+    BUILD_COMMAND bash -c "make -n && make -j$(nproc)"
+    INSTALL_COMMAND ""
+    LOG_DOWNLOAD ON
+    LOG_BUILD ON
+  )
+ExternalProject_Get_Property(htslib source_dir)
+set(HTSLIB_SOURCE_DIR ${source_dir})
+ExternalProject_Get_Property(htslib binary_dir)
+set(HTSLIB_BINARY_DIR ${binary_dir})
+
 execute_process(COMMAND git describe --tags --long --dirty --always
                 OUTPUT_VARIABLE GIT_REVISION OUTPUT_STRIP_TRAILING_WHITESPACE)
                 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DGIT_REVISION=\"\\\"${GIT_REVISION}\\\"\"")
 
 add_executable(spvcf src/main.cc src/spVCF.cc src/spVCF.h src/strlcpy.h)
-target_include_directories(spvcf PRIVATE src)
+add_dependencies(spvcf htslib)
+target_include_directories(spvcf PRIVATE src ${HTSLIB_SOURCE_DIR})
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(spvcf PRIVATE -fdiagnostics-color=auto -march=ivybridge -g)
-    set_target_properties(spvcf PROPERTIES LINK_FLAGS -static-libstdc++)
+    set_target_properties(spvcf PROPERTIES LINK_FLAGS "-static-libgcc -static-libstdc++ -pthread")
 endif()
+target_link_libraries(spvcf ${HTSLIB_BINARY_DIR}/libhts.a libz.a libbz2.a liblzma.a)
 
 include(CTest)
 add_test(NAME tests COMMAND prove -v test/spVCF.t)

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -qq update && \
      apt-get -qq install -y --no-install-recommends --no-install-suggests \
-     curl wget ca-certificates git-core less netbase \
-     g++ cmake make pigz
+     curl wget ca-certificates git-core less netbase tabix \
+     g++ cmake make pigz zlib1g-dev liblzma-dev libbz2-dev
 
 ADD . /src
 WORKDIR /src

--- a/src/spVCF.h
+++ b/src/spVCF.h
@@ -1,5 +1,7 @@
 #include <memory>
 #include <string>
+#include <vector>
+#include <iostream>
 
 namespace spVCF {
 
@@ -23,5 +25,7 @@ public:
 };
 std::unique_ptr<Transcoder> NewEncoder(uint64_t checkpoint_period, bool squeeze);
 std::unique_ptr<Transcoder> NewDecoder();
+
+void TabixSlice(const std::string& spvcf_gz, std::vector<std::string> regions, std::ostream& out);
 
 }

--- a/test/spVCF.t
+++ b/test/spVCF.t
@@ -13,15 +13,15 @@ mkdir -p $D
 plan tests 13
 
 pigz -dc "$HERE/data/small.vcf.gz" > $D/small.vcf
-"$EXE" -o $D/small.spvcf $D/small.vcf
+"$EXE" encode -o $D/small.spvcf $D/small.vcf
 is "$?" "0" "filename I/O"
 is "$(cat $D/small.spvcf | wc -c)" "36942054" "filename I/O output size"
 
-pigz -dc "$HERE/data/small.vcf.gz" | "$EXE" -q > $D/small.spvcf
+pigz -dc "$HERE/data/small.vcf.gz" | "$EXE" encode -q > $D/small.spvcf
 is "$?" "0" "piped I/O"
 is "$(cat $D/small.spvcf | wc -c)" "36942054" "piped I/O output size"
 
-"$EXE" -d -o $D/small.roundtrip.vcf $D/small.spvcf
+"$EXE" decode -o $D/small.roundtrip.vcf $D/small.spvcf
 is "$?" "0" "decode"
 is "$(cat $D/small.roundtrip.vcf | wc -c)" "54007969" "roundtrip decode"
 
@@ -33,11 +33,11 @@ is "$(egrep -o "chkptPOS=[0-9]+" $D/small.spvcf | uniq | cut -f2 -d = | tr '\n' 
    "5030088 5085728 5142746 5225415 5232998 5243839 5252753 5264502 5274001 " \
    "checkpoint positions"
 
-"$EXE" -S -p 500 -o $D/small.squeezed.spvcf $D/small.vcf
+"$EXE" encode -S -p 500 -o $D/small.squeezed.spvcf $D/small.vcf
 is "$?" "0" "squeeze"
 is "$(cat $D/small.squeezed.spvcf | wc -c)" "18714203" "squeezed output size"
 
-"$EXE" -d -q -o $D/small.squeezed.roundtrip.vcf $D/small.squeezed.spvcf
+"$EXE" decode -q -o $D/small.squeezed.roundtrip.vcf $D/small.squeezed.spvcf
 is "$?" "0" "squeezed roundtrip decode"
 is "$(cat $D/small.vcf | grep -v ^# | sed -r 's/(\t[^:]+):[^\t]+/\1/g' | sha256sum)" \
    "$(cat $D/small.squeezed.roundtrip.vcf | grep -v ^# | sed -r 's/(\t[^:]+):[^\t]+/\1/g' | sha256sum)" \

--- a/test/spVCF.t
+++ b/test/spVCF.t
@@ -10,16 +10,16 @@ D=/tmp/spVCFTests
 rm -rf $D
 mkdir -p $D
 
-plan tests 13
+plan tests 18
 
 pigz -dc "$HERE/data/small.vcf.gz" > $D/small.vcf
 "$EXE" encode -o $D/small.spvcf $D/small.vcf
 is "$?" "0" "filename I/O"
-is "$(cat $D/small.spvcf | wc -c)" "36942054" "filename I/O output size"
+is "$(cat $D/small.spvcf | wc -c)" "36986142" "filename I/O output size"
 
 pigz -dc "$HERE/data/small.vcf.gz" | "$EXE" encode -q > $D/small.spvcf
 is "$?" "0" "piped I/O"
-is "$(cat $D/small.spvcf | wc -c)" "36942054" "piped I/O output size"
+is "$(cat $D/small.spvcf | wc -c)" "36986142" "piped I/O output size"
 
 "$EXE" decode -o $D/small.roundtrip.vcf $D/small.spvcf
 is "$?" "0" "decode"
@@ -29,13 +29,13 @@ is "$(cat $D/small.vcf | grep -v ^# | sha256sum)" \
    "$(cat $D/small.roundtrip.vcf | grep -v ^# | sha256sum)" \
    "roundtrip fidelity"
 
-is "$(egrep -o "chkptPOS=[0-9]+" $D/small.spvcf | uniq | cut -f2 -d = | tr '\n' ' ')" \
+is "$(egrep -o "spVCF_checkpointPOS=[0-9]+" $D/small.spvcf | uniq | cut -f2 -d = | tr '\n' ' ')" \
    "5030088 5085728 5142746 5225415 5232998 5243839 5252753 5264502 5274001 " \
    "checkpoint positions"
 
 "$EXE" encode -S -p 500 -o $D/small.squeezed.spvcf $D/small.vcf
 is "$?" "0" "squeeze"
-is "$(cat $D/small.squeezed.spvcf | wc -c)" "18714203" "squeezed output size"
+is "$(cat $D/small.squeezed.spvcf | wc -c)" "18758214" "squeezed output size"
 
 "$EXE" decode -q -o $D/small.squeezed.roundtrip.vcf $D/small.squeezed.spvcf
 is "$?" "0" "squeezed roundtrip decode"
@@ -43,8 +43,32 @@ is "$(cat $D/small.vcf | grep -v ^# | sed -r 's/(\t[^:]+):[^\t]+/\1/g' | sha256s
    "$(cat $D/small.squeezed.roundtrip.vcf | grep -v ^# | sed -r 's/(\t[^:]+):[^\t]+/\1/g' | sha256sum)" \
    "squeezed roundtrip GT fidelity"
 
-is "$(egrep -o "chkptPOS=[0-9]+" $D/small.squeezed.spvcf | uniq | cut -f2 -d = | tr '\n' ' ')" \
+is "$(egrep -o "spVCF_checkpointPOS=[0-9]+" $D/small.squeezed.spvcf | uniq | cut -f2 -d = | tr '\n' ' ')" \
    "5030088 5053371 5085752 5111059 5142907 5219436 5225476 5229291 5233041 5238611 5244009 5248275 5252854 5257548 5265256 5271818 " \
    "squeezed checkpoint positions"
+
+bgzip -c $D/small.squeezed.spvcf > $D/small.squeezed.spvcf.gz
+tabix $D/small.squeezed.spvcf.gz
+"$EXE" tabix -o $D/small.squeezed.slice.spvcf $D/small.squeezed.spvcf.gz chr21:5143000-5219900
+is "$?" "0" "tabix slice"
+
+is "$(egrep -o "spVCF_checkpointPOS=[0-9]+" $D/small.squeezed.slice.spvcf | uniq -c | tr -d ' ' | tr '\n' ' ')" \
+   "249spVCF_checkpointPOS=5143363 20spVCF_checkpointPOS=5219436 " \
+   "slice checkpoints"
+
+"$EXE" decode $D/small.squeezed.slice.spvcf > $D/small.squeezed.slice.vcf
+is "$?" "0" "decode tabix slice"
+
+bgzip -c $D/small.squeezed.roundtrip.vcf > $D/small.squeezed.roundtrip.vcf.gz
+tabix $D/small.squeezed.roundtrip.vcf.gz
+tabix $D/small.squeezed.roundtrip.vcf.gz chr21:5143000-5219900 > $D/small.squeezed.roundtrip.slice.vcf
+is "$(cat $D/small.squeezed.slice.vcf | grep -v ^# | sha256sum)" \
+   "$(cat $D/small.squeezed.roundtrip.slice.vcf | grep -v ^# | sha256sum)" \
+   "slice fidelity"
+
+"$EXE" tabix -o $D/small.squeezed.slice_chr21.spvcf $D/small.squeezed.spvcf.gz chr21
+is "$(cat $D/small.squeezed.slice_chr21.spvcf | sha256sum)" \
+   "$(cat $D/small.squeezed.spvcf | sha256sum)" \
+   "chromosome slice"
 
 rm -rf $D

--- a/test/spVCF.t
+++ b/test/spVCF.t
@@ -15,11 +15,11 @@ plan tests 11
 pigz -dc "$HERE/data/small.vcf.gz" > $D/small.vcf
 "$EXE" -o $D/small.spvcf $D/small.vcf
 is "$?" "0" "filename I/O"
-is "$(cat $D/small.spvcf | wc -c)" "36878360" "filename I/O output size"
+is "$(cat $D/small.spvcf | wc -c)" "36873918" "filename I/O output size"
 
 pigz -dc "$HERE/data/small.vcf.gz" | "$EXE" -q > $D/small.spvcf
 is "$?" "0" "piped I/O"
-is "$(cat $D/small.spvcf | wc -c)" "36878360" "piped I/O output size"
+is "$(cat $D/small.spvcf | wc -c)" "36873918" "piped I/O output size"
 
 "$EXE" -d -o $D/small.roundtrip.vcf $D/small.spvcf
 is "$?" "0" "decode"
@@ -31,7 +31,7 @@ is "$(cat $D/small.vcf | grep -v ^# | sha256sum)" \
 
 "$EXE" -S -p 500 -o $D/small.squeezed.spvcf $D/small.vcf
 is "$?" "0" "squeeze"
-is "$(cat $D/small.squeezed.spvcf | wc -c)" "18647725" "squeezed output size"
+is "$(cat $D/small.squeezed.spvcf | wc -c)" "18646186" "squeezed output size"
 
 "$EXE" -d -q -o $D/small.squeezed.roundtrip.vcf $D/small.squeezed.spvcf
 is "$?" "0" "squeezed roundtrip decode"

--- a/test/spVCF.t
+++ b/test/spVCF.t
@@ -10,16 +10,16 @@ D=/tmp/spVCFTests
 rm -rf $D
 mkdir -p $D
 
-plan tests 11
+plan tests 13
 
 pigz -dc "$HERE/data/small.vcf.gz" > $D/small.vcf
 "$EXE" -o $D/small.spvcf $D/small.vcf
 is "$?" "0" "filename I/O"
-is "$(cat $D/small.spvcf | wc -c)" "36873918" "filename I/O output size"
+is "$(cat $D/small.spvcf | wc -c)" "36942054" "filename I/O output size"
 
 pigz -dc "$HERE/data/small.vcf.gz" | "$EXE" -q > $D/small.spvcf
 is "$?" "0" "piped I/O"
-is "$(cat $D/small.spvcf | wc -c)" "36873918" "piped I/O output size"
+is "$(cat $D/small.spvcf | wc -c)" "36942054" "piped I/O output size"
 
 "$EXE" -d -o $D/small.roundtrip.vcf $D/small.spvcf
 is "$?" "0" "decode"
@@ -29,14 +29,22 @@ is "$(cat $D/small.vcf | grep -v ^# | sha256sum)" \
    "$(cat $D/small.roundtrip.vcf | grep -v ^# | sha256sum)" \
    "roundtrip fidelity"
 
+is "$(egrep -o "chkptPOS=[0-9]+" $D/small.spvcf | uniq | cut -f2 -d = | tr '\n' ' ')" \
+   "5030088 5085728 5142746 5225415 5232998 5243839 5252753 5264502 5274001 " \
+   "checkpoint positions"
+
 "$EXE" -S -p 500 -o $D/small.squeezed.spvcf $D/small.vcf
 is "$?" "0" "squeeze"
-is "$(cat $D/small.squeezed.spvcf | wc -c)" "18646186" "squeezed output size"
+is "$(cat $D/small.squeezed.spvcf | wc -c)" "18714203" "squeezed output size"
 
 "$EXE" -d -q -o $D/small.squeezed.roundtrip.vcf $D/small.squeezed.spvcf
 is "$?" "0" "squeezed roundtrip decode"
 is "$(cat $D/small.vcf | grep -v ^# | sed -r 's/(\t[^:]+):[^\t]+/\1/g' | sha256sum)" \
    "$(cat $D/small.squeezed.roundtrip.vcf | grep -v ^# | sed -r 's/(\t[^:]+):[^\t]+/\1/g' | sha256sum)" \
    "squeezed roundtrip GT fidelity"
+
+is "$(egrep -o "chkptPOS=[0-9]+" $D/small.squeezed.spvcf | uniq | cut -f2 -d = | tr '\n' ' ')" \
+   "5030088 5053371 5085752 5111059 5142907 5219436 5225476 5229291 5233041 5238611 5244009 5248275 5252854 5257548 5265256 5271818 " \
+   "squeezed checkpoint positions"
 
 rm -rf $D


### PR DESCRIPTION
Change command-line interface to subcommands `spvcf {encode,decode,tabix} ...`

The tabix subcommand takes a genomic range slice of a bgzipped, tabix-indexed spVCF file, producing a standalone spVCF slice that can be decoded back to pVCF standalone.

Adds an INFO field to the encoded spVCF with key enabling information for tabix slicing (the POS of the last checkpoint). This field is removed while decoding back to pVCF.