### PR TITLE
Multithreaded encoder

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,9 @@
         "ostream": "cpp",
         "stdexcept": "cpp",
         "cerrno": "cpp",
-        "sstream": "cpp"
+        "sstream": "cpp",
+        "iosfwd": "cpp",
+        "mutex": "cpp",
+        "chrono": "cpp"
     }
 }

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Reads VCF text from standard input if filename is empty or -
 Options:
   -o,--output out.spvcf  Write to out.spvcf instead of standard output
   -p,--period P          Ensure checkpoints (full dense rows) at this period or less (default: 1000)
+  -t,--threads N         Use multithreaded encoder with this many worker threads [EXPERIMENTAL]
   -q,--quiet             Suppress statistics printed to standard error
   -h,--help              Show this help message
 
@@ -65,6 +66,8 @@ $ bgzip -dc my.spvcf.gz | ./spvcf decode > my.decoded.vcf
 ```
 
 There's also `spvcf squeeze` to apply the QC squeezing transformation to a pVCF, without the sparse quote-encoding.
+
+The single-threaded encoder is quite efficient. The multithreaded version is capable of higher throughput in favorable circumstances, but incurs more memory usage and copying; it should be used only with verification that it actually helps! Its memory usage scales with threads and period.
 
 ### Tabix slicing
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ bgzip -dc my.spvcf.gz | ./spvcf decode > my.decoded.vcf
 
 There's also `spvcf squeeze` to apply the QC squeezing transformation to a pVCF, without the sparse quote-encoding.
 
-The single-threaded encoder is quite efficient. The multithreaded version is capable of higher throughput in favorable circumstances, but incurs more memory usage and copying; it should be used only with verification that it actually helps! Its memory usage scales with threads and period.
+The multithreaded encoder should be used only if the single-threaded version is a proven bottleneck. It's capable of higher throughput in favorable circumstances, but trades off memory usage and copying. The memory usage scales with threads and period.
 
 ### Tabix slicing
 

--- a/spvcf.wdl
+++ b/spvcf.wdl
@@ -2,8 +2,8 @@ task spvcf {
     File in_gz
     Boolean squeeze = false
     Boolean decode = false
-    Boolean multithread = false
-    String release = "v0.3.0"
+    Boolean multithread_encode = false
+    String release = "v0.5.0"
 
     parameter_meta {
         in_gz: "stream"
@@ -18,7 +18,7 @@ task spvcf {
         chmod +x spvcf bgzip
 
         threads_arg=""
-        if [ "${multithread}" == "true" ]; then
+        if [ "${multithread_encode}" == "true" ]; then
             threads_arg="--threads $(nproc)"
         fi
 

--- a/spvcf.wdl
+++ b/spvcf.wdl
@@ -2,6 +2,7 @@ task spvcf {
     File in_gz
     Boolean squeeze = false
     Boolean decode = false
+    Boolean multithread = false
     String release = "v0.3.0"
 
     parameter_meta {
@@ -16,11 +17,16 @@ task spvcf {
         wget -nv https://github.com/dnanexus-rnd/GLnexus/raw/master/cli/dxapplet/resources/usr/local/bin/bgzip
         chmod +x spvcf bgzip
 
+        threads_arg=""
+        if [ "${multithread}" == "true" ]; then
+            threads_arg="--threads $(nproc)"
+        fi
+
         nm=$(basename "${in_gz}" .vcf.gz)
         nm=$(basename "$nm" .spvcf.gz)
         nm="$nm.${if decode then 'vcf.gz' else 'spvcf.gz'}"
         mkdir out
-        pigz -dc "${in_gz}" | ./spvcf ${if decode then 'decode' else 'encode'} ${if squeeze then '-S' else ''} | ./bgzip -@ $(nproc) > out/$nm
+        pigz -dc "${in_gz}" | ./spvcf ${if decode then 'decode' else 'encode'} ${if squeeze then '-S' else ''} $threads_arg | ./bgzip -@ $(nproc) > out/$nm
     }
 
     runtime {

--- a/src/main.cc
+++ b/src/main.cc
@@ -99,7 +99,7 @@ spVCF::transcode_stats multithreaded_encode(CodecMode mode, uint64_t checkpoint_
         }
         input_complete = true;
     }
-    if (input_stream.bad()) {
+    if (!input_stream.eof() || input_stream.bad()) {
         throw runtime_error("I/O error");
     }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -132,7 +132,7 @@ void help_codec(CodecMode mode) {
                  << "Reads VCF text from standard input if filename is empty or -" << endl << endl
                  << "Options:" << endl
                  << "  -o,--output out.vcf    Write to out.vcf instead of standard output" << endl
-                 << "  -t,--threads N         Use multithreaded encoder with this number of worker threads" << endl
+                 << "  -t,--threads N         Use multithreaded encoder with this many worker threads [EXPERIMENTAL]" << endl
                  << "  -q,--quiet             Suppress statistics printed to standard error" << endl
                  << "  -h,--help              Show this help message" << endl << endl;
             cout << "Squeezing is a lossy transformation to reduce pVCF size and increase compressibility." << endl

--- a/src/spVCF.cc
+++ b/src/spVCF.cc
@@ -10,6 +10,7 @@
 #include <climits>
 #include <assert.h>
 #include "strlcpy.h"
+#include "htslib/kstring.h"
 #include "htslib/kseq.h"
 #include "htslib/tbx.h"
 
@@ -277,12 +278,9 @@ const char* EncoderImpl::ProcessLine(char* input_line) {
     }
 
     // CHECKPOINT -- return a densely-encode row -- if we've switched to a new
-    // chromosome OR we've hit the specified period OR we've passed half the
-    // period and this line is mostly dense anyway.
+    // chromosome OR we've hit the specified period
     if (chrom_ != tokens[0] ||
-        (checkpoint_period_ > 0 &&
-         (since_checkpoint_ >= checkpoint_period_ ||
-         (since_checkpoint_*2 >= checkpoint_period_ && sparse_cells*2 >= N)))) {
+        (checkpoint_period_ > 0 && since_checkpoint_ >= checkpoint_period_)) {
         buffer_.Clear();
         for (int t = 0; t < tokens.size(); t++) {
             if (t > 0) {
@@ -662,7 +660,7 @@ public:
 
     const char* Line() const {
         if (Valid()) {
-            assert(ks_len(&str_) == strlen(str_.s));
+            assert(ks_len((kstring_t*)&str_) == strlen(str_.s));
             return str_.s;
         }
         return nullptr;

--- a/src/spVCF.h
+++ b/src/spVCF.h
@@ -16,6 +16,17 @@ struct transcode_stats {
 
     uint64_t squeezed_cells = 0;   // cells whose QC measures were dropped
     uint64_t checkpoints = 0;      // checkpoints (purposely dense rows to aid partial decoding)
+
+    void operator+=(const transcode_stats& rhs) {
+        N += rhs.N;
+        lines += rhs.lines;
+        sparse_cells += rhs.sparse_cells;
+        sparse75_lines += rhs.sparse75_lines;
+        sparse90_lines += rhs.sparse90_lines;
+        sparse99_lines += rhs.sparse99_lines;
+        squeezed_cells += rhs.squeezed_cells;
+        checkpoints += rhs.checkpoints;
+    }
 };
 
 class Transcoder {

--- a/src/spVCF.h
+++ b/src/spVCF.h
@@ -18,7 +18,7 @@ struct transcode_stats {
     uint64_t checkpoints = 0;      // checkpoints (purposely dense rows to aid partial decoding)
 
     void operator+=(const transcode_stats& rhs) {
-        // do NOT add N.
+        N = std::max(N, rhs.N);
         lines += rhs.lines;
         sparse_cells += rhs.sparse_cells;
         sparse75_lines += rhs.sparse75_lines;

--- a/src/spVCF.h
+++ b/src/spVCF.h
@@ -18,7 +18,7 @@ struct transcode_stats {
     uint64_t checkpoints = 0;      // checkpoints (purposely dense rows to aid partial decoding)
 
     void operator+=(const transcode_stats& rhs) {
-        N += rhs.N;
+        // do NOT add N.
         lines += rhs.lines;
         sparse_cells += rhs.sparse_cells;
         sparse75_lines += rhs.sparse75_lines;

--- a/test/spVCF.t
+++ b/test/spVCF.t
@@ -55,11 +55,11 @@ is "$(egrep -o "spVCF_checkpointPOS=[0-9]+" $D/small.squeezed.spvcf | uniq | cut
 
 bgzip -c $D/small.squeezed.spvcf > $D/small.squeezed.spvcf.gz
 tabix $D/small.squeezed.spvcf.gz
-"$EXE" tabix -o $D/small.squeezed.slice.spvcf $D/small.squeezed.spvcf.gz chr21:5143000-5219900
+"$EXE" tabix -o $D/small.squeezed.slice.spvcf $D/small.squeezed.spvcf.gz chr21:5143000-5226000
 is "$?" "0" "tabix slice"
 
 is "$(egrep -o "spVCF_checkpointPOS=[0-9]+" $D/small.squeezed.slice.spvcf | uniq -c | tr -d ' ' | tr '\n' ' ')" \
-   "270spVCF_checkpointPOS=5143363 " \
+   "497spVCF_checkpointPOS=5143363 28spVCF_checkpointPOS=5225415 " \
    "slice checkpoint"
 
 "$EXE" decode $D/small.squeezed.slice.spvcf > $D/small.squeezed.slice.vcf
@@ -67,7 +67,7 @@ is "$?" "0" "decode tabix slice"
 
 bgzip -c $D/small.squeezed.roundtrip.vcf > $D/small.squeezed.roundtrip.vcf.gz
 tabix $D/small.squeezed.roundtrip.vcf.gz
-tabix $D/small.squeezed.roundtrip.vcf.gz chr21:5143000-5219900 > $D/small.squeezed.roundtrip.slice.vcf
+tabix $D/small.squeezed.roundtrip.vcf.gz chr21:5143000-5226000 > $D/small.squeezed.roundtrip.slice.vcf
 is "$(cat $D/small.squeezed.slice.vcf | grep -v ^# | sha256sum)" \
    "$(cat $D/small.squeezed.roundtrip.slice.vcf | grep -v ^# | sha256sum)" \
    "slice fidelity"


### PR DESCRIPTION
The encoder can run multithreaded by buffering batches of input lines and processing each batch in a worker thread. This may yield higher throughput than the default single-threaded approach, but there is a trade-off of greatly increased memory usage and copying. Activated with `-t,--threads`