### PR TITLE
add --with-missing-fields decoder option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Further resources:
 
 ## `spvcf` utility
 
-[![Build Status](https://travis-ci.org/mlin/spVCF.svg?branch=master)](https://travis-ci.org/mlin/spVCF)
+[![build](https://github.com/mlin/spVCF/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/mlin/spVCF/actions/workflows/build.yml)
 
 This repository has a command-line utility for encoding pVCF to spVCF and vice versa. The [Releases](https://github.com/mlin/spVCF/releases) page has pre-built executables compatible with most Linux x86-64 hosts, which you can download and `chmod +x spvcf`.
 
@@ -55,9 +55,10 @@ spvcf decode [options] [in.spvcf|-]
 Reads spVCF text from standard input if filename is empty or -
 
 Options:
-  -o,--output out.vcf  Write to out.vcf instead of standard output
-  -q,--quiet           Suppress statistics printed to standard error
-  -h,--help            Show this help message
+  --with-missing-fields  Include trailing FORMAT fields with missing values
+  -o,--output out.vcf    Write to out.vcf instead of standard output
+  -q,--quiet             Suppress statistics printed to standard error
+  -h,--help              Show this help message
 ```
 
 There's also `spvcf squeeze` to apply the QC squeezing transformation to a pVCF, without the sparse quote-encoding. This produces valid pVCF that's typically much smaller, although not as small as spVCF.

--- a/spvcf.wdl
+++ b/spvcf.wdl
@@ -4,7 +4,7 @@ task spvcf_encode {
     input {
         File vcf_gz
         Boolean multithread = false
-        String docker = "ghcr.io/mlin/spvcf:v1.2.0"
+        String docker = "ghcr.io/mlin/spvcf:v1.3.0"
         Int cpu = if multithread then 8 else 4
     }
 
@@ -41,7 +41,7 @@ task spvcf_encode {
 task spvcf_decode {
     input {
         File spvcf_gz
-        String docker = "ghcr.io/mlin/spvcf:v1.2.0"
+        String docker = "ghcr.io/mlin/spvcf:v1.3.0"
     }
 
     parameter_meta {
@@ -73,7 +73,7 @@ task spvcf_squeeze {
     input {
         File vcf_gz
         Boolean multithread = false
-        String docker = "ghcr.io/mlin/spvcf:v1.2.0"
+        String docker = "ghcr.io/mlin/spvcf:v1.3.0"
         Int cpu = if multithread then 8 else 4
     }
 

--- a/spvcf.wdl
+++ b/spvcf.wdl
@@ -41,6 +41,7 @@ task spvcf_encode {
 task spvcf_decode {
     input {
         File spvcf_gz
+        Boolean with_missing_fields = false
         String docker = "ghcr.io/mlin/spvcf:v1.3.0"
     }
 
@@ -54,7 +55,9 @@ task spvcf_decode {
         nm=$(basename "~{spvcf_gz}" .spvcf.gz)
         nm="${nm}.vcf.gz"
         mkdir out
-        bgzip -dc "~{spvcf_gz}" | spvcf decode | bgzip -@ 4 > "out/${nm}"
+        bgzip -dc "~{spvcf_gz}" \
+            | spvcf decode ~{if with_missing_fields then "--with-missing-fields" else ""} \
+            | bgzip -@ 4 > "out/${nm}"
     >>>
 
     runtime {

--- a/src/main.cc
+++ b/src/main.cc
@@ -195,10 +195,11 @@ void help_codec(CodecMode mode) {
              << "Reads spVCF text from standard input if filename is empty or -" << endl
              << endl
              << "Options:" << endl
-             << "  --with-missing-fields Include trailing FORMAT fields with missing values" << endl
-             << "  -o,--output out.vcf   Write to out.vcf instead of standard output" << endl
-             << "  -q,--quiet            Suppress statistics printed to standard error" << endl
-             << "  -h,--help             Show this help message" << endl
+             << "  --with-missing-fields  Include trailing FORMAT fields with missing values"
+             << endl
+             << "  -o,--output out.vcf    Write to out.vcf instead of standard output" << endl
+             << "  -q,--quiet             Suppress statistics printed to standard error" << endl
+             << "  -h,--help              Show this help message" << endl
              << endl;
         break;
     }

--- a/src/main.cc
+++ b/src/main.cc
@@ -195,9 +195,10 @@ void help_codec(CodecMode mode) {
              << "Reads spVCF text from standard input if filename is empty or -" << endl
              << endl
              << "Options:" << endl
-             << "  -o,--output out.vcf  Write to out.vcf instead of standard output" << endl
-             << "  -q,--quiet           Suppress statistics printed to standard error" << endl
-             << "  -h,--help            Show this help message" << endl
+             << "  --with-missing-fields Include trailing FORMAT fields with missing values" << endl
+             << "  -o,--output out.vcf   Write to out.vcf instead of standard output" << endl
+             << "  -q,--quiet            Suppress statistics printed to standard error" << endl
+             << "  -h,--help             Show this help message" << endl
              << endl;
         break;
     }
@@ -206,16 +207,21 @@ void help_codec(CodecMode mode) {
 int main_codec(int argc, char *argv[], CodecMode mode) {
     bool squeeze = true;
     bool quiet = false;
+    bool with_missing_fields = false;
     string output_filename;
     uint64_t checkpoint_period = 1000;
     size_t thread_count = 1;
     double roundDP_base = 2.0;
 
-    static struct option long_options[] = {
-        {"help", no_argument, 0, 'h'},          {"no-squeeze", no_argument, 0, 'n'},
-        {"period", required_argument, 0, 'p'},  {"resolution", required_argument, 0, 'r'},
-        {"threads", required_argument, 0, 't'}, {"quiet", no_argument, 0, 'q'},
-        {"output", required_argument, 0, 'o'},  {0, 0, 0, 0}};
+    static struct option long_options[] = {{"help", no_argument, 0, 'h'},
+                                           {"no-squeeze", no_argument, 0, 'n'},
+                                           {"period", required_argument, 0, 'p'},
+                                           {"resolution", required_argument, 0, 'r'},
+                                           {"with-missing-fields", no_argument, 0, 'm'},
+                                           {"threads", required_argument, 0, 't'},
+                                           {"quiet", no_argument, 0, 'q'},
+                                           {"output", required_argument, 0, 'o'},
+                                           {0, 0, 0, 0}};
 
     int c;
     while (-1 != (c = getopt_long(argc, argv, "hnp:r:qo:t:", long_options, nullptr))) {
@@ -231,7 +237,7 @@ int main_codec(int argc, char *argv[], CodecMode mode) {
             squeeze = false;
             break;
         case 'p':
-            if (mode == CodecMode::decode) {
+            if (mode != CodecMode::encode) {
                 help_codec(mode);
                 return -1;
             }
@@ -253,6 +259,13 @@ int main_codec(int argc, char *argv[], CodecMode mode) {
                 cerr << "spvcf: invalid --resolution" << endl;
                 return -1;
             }
+            break;
+        case 'm':
+            if (mode != CodecMode::decode) {
+                help_codec(mode);
+                return -1;
+            }
+            with_missing_fields = true;
             break;
         case 't':
             if (mode == CodecMode::decode) {
@@ -322,7 +335,7 @@ int main_codec(int argc, char *argv[], CodecMode mode) {
     if (thread_count <= 1) {
         unique_ptr<spVCF::Transcoder> tc;
         if (mode == CodecMode::decode) {
-            tc = spVCF::NewDecoder();
+            tc = spVCF::NewDecoder(with_missing_fields);
         } else {
             tc = spVCF::NewEncoder(checkpoint_period, (mode == CodecMode::encode), squeeze,
                                    roundDP_base);

--- a/src/spVCF.cc
+++ b/src/spVCF.cc
@@ -591,7 +591,7 @@ const char *DecoderImpl::ProcessLine(char *input_line) {
                 }
                 continue;
             }
-        } else if (i == 8) {
+        } else if (i == 8 && with_missing_fields_) {
             // Count FORMAT fields for --with-missing-fields
             for (char *FORMAT = tokens[8]; *FORMAT != 0; FORMAT++) {
                 if (*FORMAT == ':') {
@@ -600,7 +600,7 @@ const char *DecoderImpl::ProcessLine(char *input_line) {
             }
             if (format_field_count_ <= 0) {
                 format_field_count_ = format_field_count;
-            } else if (with_missing_fields_ && format_field_count != format_field_count_) {
+            } else if (format_field_count != format_field_count_) {
                 fail(
                     "--with-missing-fields is unsuitable when pVCF lines have varying field FORMATs"
                     "; try piping output through bcftools instead");

--- a/src/spVCF.h
+++ b/src/spVCF.h
@@ -36,7 +36,7 @@ class Transcoder {
 };
 std::unique_ptr<Transcoder> NewEncoder(uint64_t checkpoint_period, bool sparse, bool squeeze,
                                        double roundDP_base);
-std::unique_ptr<Transcoder> NewDecoder();
+std::unique_ptr<Transcoder> NewDecoder(bool with_missing_fields);
 
 void TabixSlice(const std::string &spvcf_gz, std::vector<std::string> regions, std::ostream &out);
 


### PR DESCRIPTION
Adds `:.` to each cell for each omitted, trailing FORMAT field.